### PR TITLE
Bug #9 Canvas height leaking when autofit=true

### DIFF
--- a/src/angular-chartjs.js
+++ b/src/angular-chartjs.js
@@ -20,7 +20,7 @@
           oH = canvas.height;
       if (oW !== width || oH !== height) {
         canvas.width = width;
-        canvas.height = height;
+        //canvas.height = height;
         return true;
       }
       return false;


### PR DESCRIPTION
Fixes bug #9 caused when autofit=true and the parent div height is set with percentual dimensions. Commenting the line above prevents the canvas height to be incremented and the height gets same value of the width. In my case, solved the problem (didn't tested a lot).
