### PR TITLE
Modify bower dependency URL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "Chart.js": "git@github.com:nnnick/Chart.js#v1.0.1-beta.3",
+    "Chart.js": "https://github.com/nnnick/Chart.js.git~v1.0.1",
     "angular": "~1.2.21"
   },
   "devDependencies": {


### PR DESCRIPTION
When attempting to bower install under the latest version of bower, I get this message:

bower ECMDERR       Failed to execute git ls-remote --tags --heads git@github.com:nnnick/Chart.js.git, exit code of #128

Project Laverna/laverna#24 appears to have also had this issue.  Attempting similar fix
