### PR TITLE
generate new legend on dataset change

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -75,6 +75,7 @@
 
           scope.$watch('dataset', function (newData, oldData) {
             chart.initialize(newData);
+            element[0].children[1].innerHTML = chart.generateLegend();
           }, true);
 
           scope.$watch('options', function (newData, oldData) {


### PR DESCRIPTION
the chart's legend should be regenerated when the dataset changes (maybe as well when the options change, not sure)
